### PR TITLE
Feature/use action item in queue

### DIFF
--- a/src/components/ActionQueue/ActionItem.tsx
+++ b/src/components/ActionQueue/ActionItem.tsx
@@ -1,32 +1,27 @@
 import React from 'react';
-import { Button } from 'antd';
+import {Button} from 'antd';
 import '../../css/ActionQueue/ActionItem.css';
+import ActionItemProps from "../../interfaces/ActionItemPropsInterface.tsx";
 
-interface ActionItemProps {
-  name: string;
-  image: string;
-  level: string;
-  onAdd: () => void;
-}
 
-const ActionItem: React.FC<ActionItemProps> = ({ name, image, level, onAdd }) => {
-  return (
-    <div className="action-item-container">
-      {/* Image with name underneath */}
-      <div className="action-item-image-container">
-        <img src={image} alt={name} className="action-item-image" />
-        <div>{name}</div>
-      </div>
+const ActionItem: React.FC<ActionItemProps> = ({name, image, level, onAdd}) => {
+    return (
+        <div className="action-item-container">
+            {/* Image with name underneath */}
+            <div className="action-item-image-container">
+                <img src={image} alt={name} className="action-item-image"/>
+                <div>{name}</div>
+            </div>
 
-      {/* Level indicator on the right */}
-      <div className="action-item-level">{level}</div>
+            {/* Level indicator on the right */}
+            <div className="action-item-level">{level}</div>
 
-      {/* Button to add to the queue */}
-      <Button className="action-item-button" onClick={onAdd}>
-        Add
-      </Button>
-    </div>
-  );
+            {/* Button to add to the queue */}
+            {onAdd && (<Button className="action-item-button" onClick={onAdd}>
+                Add
+            </Button>)}
+        </div>
+    );
 };
 
 export default ActionItem;

--- a/src/components/ActionQueue/QueueContent.tsx
+++ b/src/components/ActionQueue/QueueContent.tsx
@@ -2,17 +2,15 @@ import React from 'react';
 import { Layout, List, Space } from 'antd';
 import '../../css/QueueContent/QueueContent.css';
 import { CloseOutlined } from '@ant-design/icons';
+import ActionItemProps from "../../interfaces/ActionItemPropsInterface.tsx";
+import ActionItem from "./ActionItem.tsx";
 
 const { Content } = Layout;
 
-interface ComponentItem {
-  name: string;
-  id: number;
-}
 
 interface QueueContentProps {
-  queue: ComponentItem[];
-  removeFromQueue: (component: ComponentItem) => void;
+  queue: ActionItemProps[];
+  removeFromQueue: (component: ActionItemProps) => void;
 }
 
 const QueueContent: React.FC<QueueContentProps> = ({ queue, removeFromQueue }) => {
@@ -25,7 +23,8 @@ const QueueContent: React.FC<QueueContentProps> = ({ queue, removeFromQueue }) =
           renderItem={(item) => (
             <List.Item>
               <Space size="large">
-                <div>{item.name}</div>
+                  <ActionItem name={item.name} image={item.image} level={item.level}></ActionItem>
+
                 <CloseOutlined
                   onClick={() => {
                     removeFromQueue(item);

--- a/src/css/Action.css
+++ b/src/css/Action.css
@@ -6,19 +6,24 @@
     align-items: center;
     align-content: center;
     background-color: peachpuff;
-    height: 200px;
+    height:100px;
     gap: 10px;
     padding: 5px;
     border-radius: 25px;
     border: solid black;
 
 }
+.ActionImageContainer img {
+    max-width: 100%;
+    height: auto;
+    object-fit: cover;
+    max-height: 200px;
+}
 .ActionSeparator {
     background-color: black;  /* Set the color of the line */
     /* Optional: Add horizontal spacing if needed */
     border: solid black;
     height: 100%;
-    align-self: stretch;      /* Make sure the separator stretches to fit */
     border-radius: 25px;
 
 }

--- a/src/interfaces/ActionItemPropsInterface.tsx
+++ b/src/interfaces/ActionItemPropsInterface.tsx
@@ -1,0 +1,8 @@
+interface ActionItemProps {
+    name: string;
+    image: string;
+    level: string;
+    onAdd: () => void;
+}
+
+export default ActionItemProps;


### PR DESCRIPTION
Created Interfaces directory.
Rendering `onAdd` button only when the property is set (so the button will disappear after items are added to queue).

Before:
![image](https://github.com/user-attachments/assets/3c257f86-66ad-4e5f-9045-4795baeed2ca)

After:
![image](https://github.com/user-attachments/assets/4bf57607-f181-470b-8713-07ab49e7745e)
